### PR TITLE
Docker-powered cross compilation for ARM32v7l (aka Raspberry Pi devices)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 **/*.rs.bk
 
 # End of https://www.gitignore.io/api/rust
+
+docker/qemu-arm-static

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ gstreamer-rtsp-server = "0.15.0"
 
 [package.metadata.deb]
 license-file=["LICENSE", "0"]
-depends="libgstrtspserver-1.0 (>=1.14.4-1), gstreamer1.0-plugins-ugly (>=1.14.4-1), gstreamer1.0-plugins-good (>=1.14.4-1), gstreamer1.0-plugins-bad (>=1.14.4-1)"
+depends="libgstrtspserver-1.0-0 (>=1.14.4-1), gstreamer1.0-plugins-ugly (>=1.14.4-1), gstreamer1.0-plugins-good (>=1.14.4-1), gstreamer1.0-plugins-bad (>=1.14.4-1)"

--- a/cross-build.sh
+++ b/cross-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# detect if sudo is required on docker
 DOCKER="docker"
 if ! ${DOCKER} ps >/dev/null 2>&1; then
     DOCKER="sudo docker"
@@ -16,6 +17,7 @@ for last in "$@"; do :; done
 docker_qemu="docker/qemu-arm-static"
 rm -f ${docker_qemu}
 cp "$(which qemu-arm-static)" ${docker_qemu}
+# build image
 ${DOCKER} build -t rusty-engine:latest docker/
 rm ${docker_qemu}
 

--- a/cross-build.sh
+++ b/cross-build.sh
@@ -23,7 +23,6 @@ if [ "${last}" == "run" ]; then
     cross build --target armv7-unknown-linux-gnueabihf --release
     ${DOCKER} run --rm --privileged \
         --volume "$(pwd)":/docking-bay \
-        --name "opsi-rusty-engine-arm" \
         rusty-engine:latest \
         bash -e -o pipefail -c \
         "cd /docking-bay; cargo deb"

--- a/cross-build.sh
+++ b/cross-build.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
 set -e
 
+DOCKER="docker"
+if ! ${DOCKER} ps >/dev/null 2>&1; then
+    DOCKER="sudo docker"
+fi
+if ! ${DOCKER} ps >/dev/null; then
+    echo "error connecting to docker:"
+    ${DOCKER} ps
+    exit 1
+fi
 # bind last argument in portable manner
 for last in "$@"; do :; done
 
 docker_qemu="docker/qemu-arm-static"
 rm -f ${docker_qemu}
 cp "$(which qemu-arm-static)" ${docker_qemu}
-docker build -t rusty-engine:latest docker/
+${DOCKER} build -t rusty-engine:latest docker/
 rm ${docker_qemu}
 
 if [ "${last}" == "run" ]; then
-    docker run --rm --privileged \
+    cross build --target armv7-unknown-linux-gnueabihf --release
+    ${DOCKER} run --rm --privileged \
         --volume "$(pwd)":/docking-bay \
         --name "opsi-rusty-engine-arm" \
         rusty-engine:latest \
         bash -e -o pipefail -c \
-        "uname -a"
+        "cd /docking-bay; cargo deb"
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,13 @@ RUN apt-get install -y build-essential curl debhelper g++-arm-linux-gnueabihf li
 # rust
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
+# TODO: somewhere around here SSL apparently goes nuts?
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain stable -y
 ENV PATH="${PATH}:/opt/cargo/bin"
 ENV RUST_TOOLCHAIN="stable"
 RUN rustup toolchain install "${RUST_TOOLCHAIN}"
 RUN rustup default "${RUST_TOOLCHAIN}"
+# deb generator
 RUN cargo install cargo-deb || true
 # gstreamer
 RUN apt-get install --no-install-recommends -y libgstreamer1.0-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ ENV PATH="${PATH}:/opt/cargo/bin"
 ENV RUST_TOOLCHAIN="stable"
 RUN rustup toolchain install "${RUST_TOOLCHAIN}"
 RUN rustup default "${RUST_TOOLCHAIN}"
+RUN cargo install cargo-deb || true
 # gstreamer
 RUN apt-get install --no-install-recommends -y libgstreamer1.0-dev \
     libgstreamer-plugins-base1.0-dev \


### PR DESCRIPTION
While Travis provides access to `aarch64` (or ARMv8 or...), enabling the 64-bit binaries it produces on Raspbian has undesirable side-effects for the rest of the image. Unfortunately, Travis also does not (yet) provide an `arm32` arch, so we have to do the cross-compiling ourselves.

This PR provides a working Dockerfile for compiling under an ARM32v7l "machine" running Debian. it also provides `cross-build.sh`, a Bash script to automatically build the Docker image and cross-compile `rusty-engine` with the aid of [`rust-emdedded/cross`](https://github.com/rust-embedded/cross).

I'd like to add it as another parallel Travis job, but odds are that will take long enough to actually be timed out.

- [x] Working Dockerfile
  - As best I can tell, the current Dockerfile works fine.<br>Please try to prove me wrong because that doesn't make sense.
  - [x] `rustup` (done in 7d247b89fb6391e4fa7ebbeaf3423919f0ae7d3a)
  - [x] `cargo-deb` (done in 2026d221186bd81d94c1e5f3fd19871b96ef67eb)
- [x] `cross-build.sh`
  - [x] Build Docker image (done in 1d87d0b239294873d91f69d2b146cdffba495b8e)
  - [x] Call on `cross` for `build` task (done in 774b476f4608688402b50974bda79f463020e888)
  - [x] Execute `cargo deb` and retrieve from container
    - Right now, it seems to be calling `cargo deb` just fine, and over the correct project, too! We'll see where the output ends up.
- [x] Configure `cross` to use Dockerfile for armv7l builds (done in de7a2e271f0b33ec7953d859653638609be1629d)
